### PR TITLE
Change license to CC0 1.0, add maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,11 +794,11 @@ These materials are here for historical reasons only, they are grouped by years 
   <tbody>
 </table>
 
+## Maintainers
+
+- Created by [@mateusortiz](https://github.com/mateusortiz) in 2014.
+- Maintained by [@web-padawan](https://github.com/web-padawan) since 2018.
+
 ## License
 
-Copyright 2014-2018, All rights reserved.
-
-Code licensed under the:
-[MIT license](http://mateusortiz.mit-license.org)
-
-@author Mateus Ortiz <mteusortiz@gmail.com>
+[![CC0](https://upload.wikimedia.org/wikipedia/commons/6/69/CC0_button.svg)](http://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Updated the license to meet current requirements of the [awesome](https://github.com/sindresorhus/awesome/blob/main/pull_request_template.md) project:

> We strongly recommend the [CC0 license](https://creativecommons.org/publicdomain/zero/1.0/), but any [Creative Commons license](https://creativecommons.org/choose/) will work.

> A code license like MIT, BSD, Apache, GPL, etc, is not acceptable. Neither are WTFPL and [Unlicense](https://unlicense.org/).